### PR TITLE
Ignoring segments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ Run parameters are passed to the workflow by a file called `config.json` that sh
 - `errors`. Either `warn` or `raise`. This controls error handling for some steps in the workflow. `warn` issues warnings if something goes wrong, but will attempt to carry on. `raise` would not carry on.
 - `qsr`. A list that can either be empty or contain some combination of `tensqr` and `abayesqr` to
   run a particular quasispecies spectrum reconstruction (QSR) algorithm. See below for more details.
+- `ignore_segments`. (Optional). A list of segments that IRMA might find to exclude from
+  all downstream processing. Names of segments should match those that IRMA
+  uses, e.g. `A_PA`, `A_NA_N1` or `A_NS`.
 
 MiSeq example:
 
@@ -157,7 +160,13 @@ MiSeq example:
     "secondary"
   ],
   "errors": "warn",
-  "qsr": ["tensqr"]
+  "qsr": [
+    "tensqr"
+  ],
+  "ignore_segments": [
+    "A_NS",
+    "A_PA"
+  ]
 }
 ```
 

--- a/workflow/irma.smk
+++ b/workflow/irma.smk
@@ -222,7 +222,9 @@ def collect_segments(path, default_wildcards=None):
         Make a list of files containing segment names, based on segments that IRMA has found.
         """
         irma_dir = checkpoints.find_irma_output.get(**wildcards, **default_wildcards).output[0]
-        segments = [path.stem for path in Path(irma_dir).glob("*.vcf")]
+        found_segments = set(path.stem for path in Path(irma_dir).glob("*.vcf"))
+        ignored_segments = config.get("ignore_segments", set())
+        segments = sorted(found_segments - ignored_segments)
         return expand(path, segment=segments, **wildcards)
 
     return fun

--- a/workflow/irma.smk
+++ b/workflow/irma.smk
@@ -223,7 +223,7 @@ def collect_segments(path, default_wildcards=None):
         """
         irma_dir = checkpoints.find_irma_output.get(**wildcards, **default_wildcards).output[0]
         found_segments = set(path.stem for path in Path(irma_dir).glob("*.vcf"))
-        ignored_segments = config.get("ignore_segments", set())
+        ignored_segments = set(config.get("ignore_segments", []))
         segments = sorted(found_segments - ignored_segments)
         return expand(path, segment=segments, **wildcards)
 

--- a/workflow/schemas/config-schema.json
+++ b/workflow/schemas/config-schema.json
@@ -42,6 +42,14 @@
             },
             "minItems": 0,
             "uniqueItems": true
+        },
+        "ignored_segments": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "minItems": 0,
+            "uniqueItems": true
         }
     },
     "required": [


### PR DESCRIPTION
Lavanya had been running a sample where the GFF file for NS wasn't created correctly, which then caused errors.

In this case we're not particularly interested in NS, so it might be useful to be able to ignore segments.